### PR TITLE
fix: pin NeuNorm to pre-2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - sphinx_rtd_theme
   # pip
   - pip:
-    - NeuNorm
+    - NeuNorm<2
     - olefile
     - pyqtgraph
     - six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # pip
-NeuNorm
+NeuNorm<2
 GPUlib


### PR DESCRIPTION
## Summary

NeuNorm **2.0.0 is now the latest release on PyPI** — a breaking scipp-based rewrite (the `NeuNorm.normalization.Normalization` API used by the loader/reconstruction code no longer exists). The unpinned references in `environment.yml` (pip section) and `requirements.txt` install a version this code cannot import.

Pin to `<2`. This repo is low-activity (last push 2024-03), so freezing on the 1.x API is the likely end state — tracked in the group-wide NeuNorm migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)